### PR TITLE
Remove normalizer.js from webchat license information

### DIFF
--- a/docs/web-chat/licensing.mdx
+++ b/docs/web-chat/licensing.mdx
@@ -47,7 +47,7 @@ Web Chat widget uses following third party Javascript libraries:
 |         |                                                                        |
 | ------- | ---------------------------------------------------------------------- |
 | Version | v15.4.2                                                                |
-| Purpose | Javascript library for building user interfaces                        |
+| Purpose | JavaScript library for building user interfaces                        |
 | Source  | [https://github.com/facebook/react](https://github.com/facebook/react) |
 | License | [BSD](https://github.com/facebook/react#license)                       |
 

--- a/docs/web-chat/licensing.mdx
+++ b/docs/web-chat/licensing.mdx
@@ -4,106 +4,103 @@ title: License Information
 description: "Web Chat widget uses following third party Javascript libraries:"
 ---
 
-import {Admonition, CodeBlock, Tabs, TabItem, LatestSdkVersion, Centered, Image, Intro, SideBySide, DownloadButton, Steps, Step} from "@site/src/components/forDocs"
-
-
-
+import {
+  Admonition,
+  CodeBlock,
+  Tabs,
+  TabItem,
+  LatestSdkVersion,
+  Centered,
+  Image,
+  Intro,
+  SideBySide,
+  DownloadButton,
+  Steps,
+  Step,
+} from "@site/src/components/forDocs";
 
 # License Information
+
 <Intro>
 
 Web Chat widget uses following third party Javascript libraries:
 
-
 </Intro>
 
-
 ## require.js {#require-js}
+
 <div className="compact ">
 
+|         |                                                                                  |
+| ------- | -------------------------------------------------------------------------------- |
+| Version | v2.3.3                                                                           |
+| Purpose | Javascript module loader                                                         |
+| Source  | [https://github.com/requirejs/requirejs](https://github.com/requirejs/requirejs) |
+| License | MIT                                                                              |
 
-| | |
-|--|--|
-|Version| v2.3.3|
-|Purpose| Javascript module loader|
-|Source| [https://github.com/requirejs/requirejs](https://github.com/requirejs/requirejs)|
-|License| MIT|
 </div>
-
 
 ## react-with-addons.js {#react-with-addons-js}
+
 <div className="compact ">
 
+|         |                                                                        |
+| ------- | ---------------------------------------------------------------------- |
+| Version | v15.4.2                                                                |
+| Purpose | Javascript library for building user interfaces                        |
+| Source  | [https://github.com/facebook/react](https://github.com/facebook/react) |
+| License | [BSD](https://github.com/facebook/react#license)                       |
 
-| | |
-|--|--|
-|Version| v15.4.2|
-|Purpose| Javascript library for building user interfaces|
-|Source| [https://github.com/facebook/react](https://github.com/facebook/react)|
-|License| [BSD](https://github.com/facebook/react#license)|
 </div>
-
 
 ## react-dom.js {#react-dom-js}
+
 <div className="compact ">
 
+|         |                                                                                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Version | v15.4.2                                                                                                                              |
+| Purpose | Helper package for React library                                                                                                     |
+| Source  | [https://github.com/facebook/react/tree/master/packages/react-dom](https://github.com/facebook/react/tree/master/packages/react-dom) |
+| License | [BSD](https://github.com/facebook/react#license)                                                                                     |
 
-| | |
-|--|--|
-|Version| v15.4.2|
-|Purpose| Helper package for React library|
-|Source| [https://github.com/facebook/react/tree/master/packages/react-dom](https://github.com/facebook/react/tree/master/packages/react-dom)|
-|License| [BSD](https://github.com/facebook/react#license)|
 </div>
-
 
 ## redux.js {#redux-js}
+
 <div className="compact ">
 
+|         |                                                                      |
+| ------- | -------------------------------------------------------------------- |
+| Version | v3.7.2                                                               |
+| Purpose | State container for React app                                        |
+| Source  | [https://github.com/reactjs/redux](https://github.com/reactjs/redux) |
+| License | MIT                                                                  |
 
-| | |
-|--|--|
-|Version| v3.7.2|
-|Purpose| State container for React app|
-|Source| [https://github.com/reactjs/redux](https://github.com/reactjs/redux)|
-|License| MIT|
 </div>
-
 
 ## react-redux.js {#react-redux-js}
+
 <div className="compact ">
 
+|         |                                                                                  |
+| ------- | -------------------------------------------------------------------------------- |
+| Version | v5.0.6                                                                           |
+| Purpose | React bindings for Redux                                                         |
+| Source  | [https://github.com/reactjs/react-redux](https://github.com/reactjs/react-redux) |
+| License | MIT                                                                              |
 
-| | |
-|--|--|
-|Version| v5.0.6|
-|Purpose| React bindings for Redux|
-|Source| [https://github.com/reactjs/react-redux](https://github.com/reactjs/react-redux)|
-|License| MIT|
 </div>
-
 
 ## redux-thunk.js {#redux-thunk-js}
+
 <div className="compact ">
 
+|         |                                                                                  |
+| ------- | -------------------------------------------------------------------------------- |
+| Version | v2.2.0                                                                           |
+| Purpose | Redux middleware to dispatch asycn actions                                       |
+| Source  | [https://github.com/gaearon/redux-thunk](https://github.com/gaearon/redux-thunk) |
+| License | MIT                                                                              |
 
-| | |
-|--|--|
-|Version| v2.2.0|
-|Purpose| Redux middleware to dispatch asycn actions|
-|Source| [https://github.com/gaearon/redux-thunk](https://github.com/gaearon/redux-thunk)|
-|License| MIT|
-</div>
-
-
-## normalizr.js {#normalizr-js}
-<div className="compact ">
-
-
-| | |
-|--|--|
-|Version| v3.2.3|
-|Purpose| Normalizes nested JSON according to a schema. (For Redux state)|
-|Source| [https://github.com/paularmstrong/normalizr](https://github.com/paularmstrong/normalizr)|
-|License| MIT|
 </div>

--- a/docs/web-chat/licensing.mdx
+++ b/docs/web-chat/licensing.mdx
@@ -99,7 +99,7 @@ Web Chat widget uses following third party Javascript libraries:
 |         |                                                                                  |
 | ------- | -------------------------------------------------------------------------------- |
 | Version | v2.2.0                                                                           |
-| Purpose | Redux middleware to dispatch asycn actions                                       |
+| Purpose | Redux middleware to dispatch async actions                                       |
 | Source  | [https://github.com/gaearon/redux-thunk](https://github.com/gaearon/redux-thunk) |
 | License | MIT                                                                              |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "helpshift-docs",
       "version": "0.0.0",
+      "license": "UNLICENSED",
       "dependencies": {
         "@docusaurus/core": "^2.2.0",
         "@docusaurus/preset-classic": "^2.2.0",
@@ -22,6 +23,7 @@
         "@docusaurus/eslint-plugin": "^2.2.0",
         "@docusaurus/module-type-aliases": "^2.2.0",
         "autoprefixer": "^10.4.11",
+        "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsx-a11y": "^6.6.1",
@@ -2625,7 +2627,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
       "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -2649,7 +2650,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
       "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2665,7 +2665,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "devOptional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2691,7 +2690,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
       "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -2706,7 +2704,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "devOptional": true,
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2719,8 +2716,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/@jest/schemas": {
       "version": "29.0.0",
@@ -4097,7 +4093,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "devOptional": true,
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -5893,8 +5888,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -6110,7 +6104,6 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -6442,11 +6435,10 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
-      "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
+      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -6797,7 +6789,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -6811,7 +6802,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -6824,7 +6814,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
       "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -6840,7 +6829,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "devOptional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6853,7 +6841,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
       "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -6883,7 +6870,6 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -7129,8 +7115,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -7202,7 +7187,6 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -7331,7 +7315,6 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -7344,8 +7327,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/flux": {
       "version": "4.0.3",
@@ -7809,8 +7791,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -9087,7 +9068,6 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
       "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
       "devOptional": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -9139,8 +9119,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -9256,7 +9235,6 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -9342,8 +9320,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -9727,8 +9704,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -10048,7 +10024,6 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -11109,7 +11084,6 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "devOptional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -11725,7 +11699,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "devOptional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -13370,7 +13343,6 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -14579,7 +14551,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "devOptional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16574,7 +16545,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
       "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -16592,7 +16562,6 @@
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
           "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
           "devOptional": true,
-          "peer": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -16601,8 +16570,7 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "devOptional": true,
-          "peer": true
+          "devOptional": true
         }
       }
     },
@@ -16624,7 +16592,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
       "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -16635,15 +16602,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "@jest/schemas": {
       "version": "29.0.0",
@@ -17646,7 +17611,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "devOptional": true,
-      "peer": true,
       "requires": {}
     },
     "acorn-node": {
@@ -18926,8 +18890,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -19087,7 +19050,6 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -19345,11 +19307,10 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
-      "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
+      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -19397,7 +19358,6 @@
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
           "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
           "devOptional": true,
-          "peer": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
@@ -19408,7 +19368,6 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "devOptional": true,
-          "peer": true,
           "requires": {
             "is-glob": "^4.0.3"
           }
@@ -19418,7 +19377,6 @@
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
           "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
           "devOptional": true,
-          "peer": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -19427,8 +19385,7 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "devOptional": true,
-          "peer": true
+          "devOptional": true
         }
       }
     },
@@ -19663,7 +19620,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
       "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -19680,7 +19636,6 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "estraverse": "^5.1.0"
       }
@@ -19876,8 +19831,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -19943,7 +19897,6 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -20035,7 +19988,6 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -20045,8 +19997,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "flux": {
       "version": "4.0.3",
@@ -20370,8 +20321,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -21264,8 +21214,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
       "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -21304,8 +21253,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "json5": {
       "version": "2.2.3",
@@ -21395,7 +21343,6 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -21463,8 +21410,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -21742,8 +21688,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "negotiator": {
       "version": "0.6.3",
@@ -21965,7 +21910,6 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -22637,8 +22581,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -23110,8 +23053,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "regexpu-core": {
       "version": "5.2.2",
@@ -24349,7 +24291,6 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -25162,8 +25103,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "wrap-ansi": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@docusaurus/eslint-plugin": "^2.2.0",
     "@docusaurus/module-type-aliases": "^2.2.0",
     "autoprefixer": "^10.4.11",
+    "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",

--- a/src/components/forDocs/LatestSdkVersion.jsx
+++ b/src/components/forDocs/LatestSdkVersion.jsx
@@ -4,7 +4,6 @@
  * to highlight latest SDK versions better
  */
 
-import React from "react";
 import PropTypes from "prop-types";
 
 export default function LatestSdkVersion({ children }) {


### PR DESCRIPTION
### Description

- Remove normalizer.js from webchat license information
- Remove React global imports from LatestSdkVersion file
- Add eslint package in the helpshift developer docs

### Type of change
- Bug fixes