### PR TITLE
Update migration-guide.mdx

### DIFF
--- a/docs/sdkx_ios/migration-guide.mdx
+++ b/docs/sdkx_ios/migration-guide.mdx
@@ -413,7 +413,6 @@ Legacy SDK methods that are unsupported in SDK X and don't have a corresponding 
 - `didCheckIfConversationActive`
 
 ## Review and Feedback {#review-feedback}
-  
 
 - Manual App Review Request by Agent is Supported in SDK X — [Manual App Review Request by Agent](https://support.helpshift.com/hc/en/13-helpshift-technical-support/faq/782-in-app-support-what-is-the-send-review-request-function-how-do-i-use-it/)
   

--- a/docs/sdkx_ios/migration-guide.mdx
+++ b/docs/sdkx_ios/migration-guide.mdx
@@ -412,9 +412,14 @@ Legacy SDK methods that are unsupported in SDK X and don't have a corresponding 
 - `displayAttachmentFileAtLocation:onViewController:`
 - `didCheckIfConversationActive`
 
-#### Reviews & Feedback
+## Review and Feedback {#review-feedback}
+  
 
-Review & feedback related APIs are currently not supported in SDK X.
+- Manual App Review Request by Agent is Supported in SDK X — [Manual App Review Request by Agent](https://support.helpshift.com/hc/en/13-helpshift-technical-support/faq/782-in-app-support-what-is-the-send-review-request-function-how-do-i-use-it/)
+  
+- Manual app rating request is not supported in SDK X — [Manual App Rating - Helpshift for iOS](https://developers.helpshift.com/ios/reviews-and-feedback/#app-rating-api)
+
+- Automatic review request is not supported in SDK X — [Automatic Reviews - Helpshift for iOS](https://developers.helpshift.com/ios/reviews-and-feedback/#automatic-review-request)
 
 #### Deep linking
 

--- a/docs/sdkx_ios/migration-guide.mdx
+++ b/docs/sdkx_ios/migration-guide.mdx
@@ -416,7 +416,6 @@ Legacy SDK methods that are unsupported in SDK X and don't have a corresponding 
 
 - Manual App Review Request by Agent is Supported in SDK X — [Manual App Review Request by Agent](https://support.helpshift.com/hc/en/13-helpshift-technical-support/faq/782-in-app-support-what-is-the-send-review-request-function-how-do-i-use-it/)
 - Manual app rating request is not supported in SDK X — [Manual App Rating - Helpshift for iOS](https://developers.helpshift.com/ios/reviews-and-feedback/#app-rating-api)
-
 - Automatic review request is not supported in SDK X — [Automatic Reviews - Helpshift for iOS](https://developers.helpshift.com/ios/reviews-and-feedback/#automatic-review-request)
 
 #### Deep linking

--- a/docs/sdkx_ios/migration-guide.mdx
+++ b/docs/sdkx_ios/migration-guide.mdx
@@ -415,7 +415,6 @@ Legacy SDK methods that are unsupported in SDK X and don't have a corresponding 
 ## Review and Feedback {#review-feedback}
 
 - Manual App Review Request by Agent is Supported in SDK X — [Manual App Review Request by Agent](https://support.helpshift.com/hc/en/13-helpshift-technical-support/faq/782-in-app-support-what-is-the-send-review-request-function-how-do-i-use-it/)
-  
 - Manual app rating request is not supported in SDK X — [Manual App Rating - Helpshift for iOS](https://developers.helpshift.com/ios/reviews-and-feedback/#app-rating-api)
 
 - Automatic review request is not supported in SDK X — [Automatic Reviews - Helpshift for iOS](https://developers.helpshift.com/ios/reviews-and-feedback/#automatic-review-request)


### PR DESCRIPTION
On Parity with Android SDK X, only Manual App Review Request by Agent is Supported