### PR TITLE
Update iOS SDK X configuration page title

### DIFF
--- a/docs/sdkx_ios/sdk-configuration.mdx
+++ b/docs/sdkx_ios/sdk-configuration.mdx
@@ -19,7 +19,7 @@ import {
   Step,
 } from "@site/src/components/forDocs";
 
-# API Options
+# SDK Configuration
 
 <Intro>
 


### PR DESCRIPTION
We have named all the configuration pages "SDK Configuration" in every space. It should be the same here as well.