### PR TITLE
Improve android migration docs. Fix function call

### DIFF
--- a/docs/sdkx-unity/migration-guide-android.mdx
+++ b/docs/sdkx-unity/migration-guide-android.mdx
@@ -225,7 +225,7 @@ The API signatures have changed. Update existing API calls with new ones as ment
 
 | Action                       | Legacy SDK Unity plugin API                                     | SDK X Unity plugin API                                          |
 | ---------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------- |
-| Register device token        | `HelpshiftSdk.GetInstance().registerDeviceToken ("fcm-token");` | `HelpshiftSdk.GetInstance().RegisterDeviceToken ("fcm-token");` |
+| Register device token        | `HelpshiftSdk.GetInstance().registerDeviceToken ("fcm-token");` | `HelpshiftSdk.GetInstance().RegisterPushToken ("fcm-token");` |
 | Request unread message count | `requestUnreadMessagesCount(isAsync)`                           | `RequestUnreadMessageCount(shouldFetchFromServer)`              |
 
 The delegate method that receives the unread message count has also changed, Legacy SDK Code -


### PR DESCRIPTION
The current function call for Register Device Token is misleading. Fix to use the correct function.