### PR TITLE
Replace the "customIssueFields" key with the "cifs" key in different docs

### DIFF
--- a/docs/freesdk/getting-started-android.mdx
+++ b/docs/freesdk/getting-started-android.mdx
@@ -136,7 +136,7 @@ Example:
     isPro.put("value", "true");
     cifMap.put("is_pro", isPro);
 
-    config.put("customIssueFields", cifMap);
+    config.put("cifs", cifMap);
     config.put("initialUserMessage", "Give Feedback");
 
     //..etc
@@ -203,7 +203,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 2. Define your custom issue field `Map`
 3. Add the `"type"` and `"value"` for that custom issue field
 4. Add the custom issue field map to top level map (with key as your configured key and value as custom issue field map)
-5. Pass the map to `configMap` with key `"customIssueFields"` of the `Helpshift.showConversation(this, configMap)`
+5. Pass the map to `configMap` with key `"cifs"` of the `Helpshift.showConversation(this, configMap)`
 
 ```java
 
@@ -233,7 +233,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
     Map<String, Object> config = new HashMap<>();
     // other configs...
     //..
-    config.put("customIssueFields", cifMap);
+    config.put("cifs", cifMap);
 
     Helpshift.showConversation(MainActivity.this, config);
 

--- a/docs/freesdk/getting-started-android.mdx
+++ b/docs/freesdk/getting-started-android.mdx
@@ -146,6 +146,12 @@ Example:
 
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 `Helpshift.showConversation(MyActivity.this, configMap);` where `MyActivity.this` is the Activity you're calling Helpshift from and `configMap` is the configuration map that you want to pass to configure the SDK.
 
 ## Integrating FAQs {#faqs-view}
@@ -239,6 +245,12 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 
 
 ```
+
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
 
 The following are the valid values for the `type` key of a Custom Issue Field.
 

--- a/docs/freesdk/getting-started-ios.mdx
+++ b/docs/freesdk/getting-started-ios.mdx
@@ -408,3 +408,9 @@ Helpshift.showConversation(with: self, config: config)
 </TabItem>
 
 </Tabs>
+
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>

--- a/docs/freesdk/getting-started-ios.mdx
+++ b/docs/freesdk/getting-started-ios.mdx
@@ -350,7 +350,7 @@ Helpshift.showConversation(with: self, config: config)
 
 </Admonition>
 
-You can attach Custom Issue Fields to every new feedback started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `customIssueFields` method in the ApiConfig object.
+You can attach Custom Issue Fields to every new feedback started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `cifs` method in the ApiConfig object.
 These Custom Issue Fields would be sent whenever a new feedback is started by the end user.
 
 As soon as an end user opens the feedback screen, they see a greeting message, and the feedback is considered active.
@@ -384,7 +384,7 @@ NSDictionary *cifs = @{ @"joining_date": @{ @"type":@"date", @"value":@150592736
                     @"employee_address": @{ @"type":@"multiline", @"value":@"303,Joy plaza,Park street,Viman nagar.Pune-432123" },
                      @"salary_currency": @{ @"type":@"dropdown", @"value":@"Dollars" } };
 
-NSDictionary *config = @{ @"customIssueFields" : cifs };
+NSDictionary *config = @{ @"cifs" : cifs };
 [Helpshift showConversationWith:self config:config];
 ```
 
@@ -397,7 +397,7 @@ let cifs = [ "joining_date": [ "type":"date", "value":1505927361535 ],
                                "employee_name": [ "type":"singleline", "value":"ABC" ],
                             "employee_address": [ "type":"multiline", "value":"303,Joy plaza,Park street,Viman nagar.Pune-432123" ],
                              "salary_currency": [ "type":"dropdown", "value":"Dollars" ] ];
-let config = ["customIssueFields":cifs]
+let config = ["cifs":cifs]
 Helpshift.showConversation(with: self, config: config)
 ```
 

--- a/docs/freesdk/getting-started-unity-android.mdx
+++ b/docs/freesdk/getting-started-unity-android.mdx
@@ -357,6 +357,12 @@ void openHelpshift(){
 }
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 The following are the valid values for the `type` key of a Custom Issue Field.
 
 - "singleline"

--- a/docs/freesdk/getting-started-unity-android.mdx
+++ b/docs/freesdk/getting-started-unity-android.mdx
@@ -312,7 +312,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 2. Define your custom issue field `Dictionary`
 3. Add the `"type"` and `"value"` for that custom issue field
 4. Add the custom issue field map to top level map (with key as your configured key and value as custom issue field map)
-5. Pass the map to `configMap` with key `"customIssueFields"` of the `ShowConversation(configMap)`
+5. Pass the map to `configMap` with key `"cifs"` of the `ShowConversation(configMap)`
 
 ```csharp
 using Helpshift;
@@ -351,7 +351,7 @@ void openHelpshift(){
     Dictionary<string, object> config = new Dictionary<string, object>();
     // other configs...
     //..
-    config.Add("customIssueFields", cifDictionary);
+    config.Add("cifs", cifDictionary);
 
     help.ShowConversation(configMap);
 }

--- a/docs/freesdk/getting-started-unity-ios.mdx
+++ b/docs/freesdk/getting-started-unity-ios.mdx
@@ -357,6 +357,12 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 The following are the valid values for the `type` key of a Custom Issue Field.
 
 - "singleline"

--- a/docs/freesdk/getting-started-unity-ios.mdx
+++ b/docs/freesdk/getting-started-unity-ios.mdx
@@ -320,7 +320,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 2. Define your custom issue field `Dictionary`
 3. Add the `"type"` and `"value"` for that custom issue field
 4. Add the custom issue field map to top level map (with key as your configured key and value as custom issue field map)
-5. Pass the map to `configMap` with key `"customIssueFields"` of the `ShowConversation(configMap)`
+5. Pass the map to `configMap` with key `"cifs"` of the `ShowConversation(configMap)`
 
 ```csharp
 
@@ -350,7 +350,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
     Map<String, Object> config = new HashMap<>();
     // other configs...
     //..
-    config.put("customIssueFields", cifMap);
+    config.put("cifs", cifMap);
 
     Helpshift.showConversation(MainActivity.this, config);
 

--- a/docs/sdkx-react-native/outbound-support.mdx
+++ b/docs/sdkx-react-native/outbound-support.mdx
@@ -105,6 +105,12 @@ const localConfig = {
 handleProactiveLink(notificationData.helpshift_proactive_link, localConfig);
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 ## Sending the generated link to device {#send-generated-link-to-device}
 
 1. Send push notifications to the users you want to give proactive support using your app's existing push notification system. Embed the outbound support link in the notification payload.

--- a/docs/sdkx-react-native/outbound-support.mdx
+++ b/docs/sdkx-react-native/outbound-support.mdx
@@ -97,13 +97,14 @@ Example :
 ```javascript
 const cifs = { stock_level: { type: 'number', value: '1505' } };
 
-const localConfig = { 
+const localConfig = {
   tags:<Tags_Array>,
-  customIssueFields: cifs' 
+  cifs: cifs
 };
 
 handleProactiveLink(notificationData.helpshift_proactive_link, localConfig);
 ```
+
 ## Sending the generated link to device {#send-generated-link-to-device}
 
 1. Send push notifications to the users you want to give proactive support using your app's existing push notification system. Embed the outbound support link in the notification payload.

--- a/docs/sdkx-react-native/tracking.mdx
+++ b/docs/sdkx-react-native/tracking.mdx
@@ -111,6 +111,12 @@ const config = {
 showConversation(config);
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 Similarly, you can pass this Map to other APIs (ie. `showConversation`, `showFAQsWithConfig`, `showFAQSectionWithConfig`).
 
 The following are the valid values for the `type` key of a Custom Issue Field.

--- a/docs/sdkx-react-native/tracking.mdx
+++ b/docs/sdkx-react-native/tracking.mdx
@@ -72,6 +72,7 @@ showConversation(config);
 ```
 
 `showFAQsWithConfig` API,
+
 ```javascript
 const customMetadata = { usertype:'paid', level:'7', score: '1505' } };
  const config = {
@@ -81,6 +82,7 @@ showFAQsWithConfig(config);
 ```
 
 `showFAQSectionWithConfig` API
+
 ```javascript
 const customMetadata = { usertype:'paid', level:'7', score: '1505' } };
  const config = {
@@ -96,15 +98,15 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 1. Initialise a top-level custom issue fields `Map`
 2. Define your custom issue field `Map`
 3. Add the `"type"` and `"value"` for that custom issue field
-   
 
 Pass this Map to `showConversation` API.
 
 Example:
+
 ```javascript
-const CIFs = { stock_level: { type: 'number', value: '1505' } };
+const CIFs = { stock_level: { type: "number", value: "1505" } };
 const config = {
-  customIssueFields: CIFs,
+  cifs: CIFs,
 };
 showConversation(config);
 ```
@@ -152,21 +154,21 @@ leaveBreadCrumb(<breadCrumbString>)
 ```
 
 Breadcrumbs are collected within the set breadcrumb limit. The limit is set under the SDK Configurations section for App Settings in the Helpshift’s Agent Dashboard. Breadcrumbs are collected in a FIFO queue. If you want to clear the breadcrumbs, use the `clearBreadcrumbs` API. For example -
-```javascript
-import {
-  clearBreadcrumbs
-} from 'helpshift-plugin-sdkx-react-native';
 
-clearBreadcrumbs()
+```javascript
+import { clearBreadcrumbs } from "helpshift-plugin-sdkx-react-native";
+
+clearBreadcrumbs();
 ```
+
 <Admonition type="info" title="Note">
 
 In the **Breadcrumbs** and **Debug logs** APIs, the passing of formatted strings is NOT supported. It is recommended to pass data only in a simple String format.
 
 <p className="m-0">For example:</p>
 
-* "{\"key\":\"value\"}" - ** JSON String, This is NOT supported **
-* "key - value" - ** Simple string, This is supported **
+- "{\"key\":\"value\"}" - ** JSON String, This is NOT supported **
+- "key - value" - ** Simple string, This is supported **
 
 </Admonition>
 

--- a/docs/sdkx-unity/migration-guide-android.mdx
+++ b/docs/sdkx-unity/migration-guide-android.mdx
@@ -223,10 +223,10 @@ String customization is yet to be supported. It will move to Helpshift Dashboard
 
 The API signatures have changed. Update existing API calls with new ones as mentioned -
 
-| Action                       | Legacy SDK Unity plugin API                                     | SDK X Unity plugin API                                          |
-| ---------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------- |
+| Action                       | Legacy SDK Unity plugin API                                     | SDK X Unity plugin API                                        |
+| ---------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------- |
 | Register device token        | `HelpshiftSdk.GetInstance().registerDeviceToken ("fcm-token");` | `HelpshiftSdk.GetInstance().RegisterPushToken ("fcm-token");` |
-| Request unread message count | `requestUnreadMessagesCount(isAsync)`                           | `RequestUnreadMessageCount(shouldFetchFromServer)`              |
+| Request unread message count | `requestUnreadMessagesCount(isAsync)`                           | `RequestUnreadMessageCount(shouldFetchFromServer)`            |
 
 The delegate method that receives the unread message count has also changed, Legacy SDK Code -
 
@@ -425,7 +425,7 @@ cifDictionary.Add("is_pro", isPro);
 cifDictionary.Add("currency", currency);
 
 Map<String, Object> config = new HashMap<>();
-config.put("customIssueFields", cifMap);
+config.put("cifs", cifMap);
 _support.ShowFAQs(MainActivity.this, config);
 ```
 

--- a/docs/sdkx-unity/migration-guide-android.mdx
+++ b/docs/sdkx-unity/migration-guide-android.mdx
@@ -429,6 +429,12 @@ config.put("cifs", cifMap);
 _support.ShowFAQs(MainActivity.this, config);
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 #### Breadcrumbs
 
 The APIs for breadcrumbs have changed -

--- a/docs/sdkx-unity/migration-guide-ios.mdx
+++ b/docs/sdkx-unity/migration-guide-ios.mdx
@@ -152,7 +152,7 @@ The mapping of config dictionary keys are -
 
 | Legacy SDK Unity plugin config dictionary key | SDK X Unity plugin config dictionary key | Notes                                                                                                 |
 | --------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `Helpshift.HSCUSTOMISSUEFIELDKEY`             | `customIssueFields`                      | -                                                                                                     |
+| `Helpshift.HSCUSTOMISSUEFIELDKEY`             | `cifs`                                   | -                                                                                                     |
 | `enableFullPrivacy`                           | `fullPrivacy`                            | -                                                                                                     |
 | `presentFullScreenOniPad`                     | `presentFullScreenOniPad`                | -                                                                                                     |
 | `enableTypingIndicator`                       | -                                        | Moved to admin dashboard under App settings → Support Experience → Show Agent Typing Indicator toggle |
@@ -426,7 +426,7 @@ cifDictionary.Add("is_pro", isPro);
 cifDictionary.Add("currency", currency);
 
 Map<String, Object> config = new HashMap<>();
-config.put("customIssueFields", cifMap);
+config.put("cifs", cifMap);
 _support.ShowFAQs(MainActivity.this, config);
 ```
 

--- a/docs/sdkx-unity/migration-guide-ios.mdx
+++ b/docs/sdkx-unity/migration-guide-ios.mdx
@@ -430,6 +430,12 @@ config.put("cifs", cifMap);
 _support.ShowFAQs(MainActivity.this, config);
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 #### Breadcrumbs
 
 The APIs for breadcrumbs have changed -

--- a/docs/sdkx-unity/tracking-android.mdx
+++ b/docs/sdkx-unity/tracking-android.mdx
@@ -168,6 +168,12 @@ void openHelpshift(){
 }
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 The following are the valid values for the `type` key of a Custom Issue Field.
 
 - "singleline"

--- a/docs/sdkx-unity/tracking-android.mdx
+++ b/docs/sdkx-unity/tracking-android.mdx
@@ -123,7 +123,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 2. Define your custom issue field `Dictionary`
 3. Add the `"type"` and `"value"` for that custom issue field
 4. Add the custom issue field map to top level map (with key as your configured key and value as custom issue field map)
-5. Pass the map to `configMap` with key `"customIssueFields"` of the `ShowConversation(configMap)`
+5. Pass the map to `configMap` with key `"cifs"` of the `ShowConversation(configMap)`
 
 ```csharp
 using Helpshift;
@@ -162,7 +162,7 @@ void openHelpshift(){
     Dictionary<string, object> config = new Dictionary<string, object>();
     // other configs...
     //..
-    config.Add("customIssueFields", cifDictionary);
+    config.Add("cifs", cifDictionary);
 
     help.ShowConversation(configMap);
 }
@@ -202,8 +202,8 @@ In the **Breadcrumbs** and **Debug logs** APIs, passing of formatted strings is 
 
 <p className="m-0">For example:</p>
 
-* "{\"key\":\"value\"}" - ** JSON String, This is NOT supported **
-* "key - value" - ** Simple string, This is supported **
+- "{\"key\":\"value\"}" - ** JSON String, This is NOT supported **
+- "key - value" - ** Simple string, This is supported **
 
 </Admonition>
 

--- a/docs/sdkx-unity/tracking-ios.mdx
+++ b/docs/sdkx-unity/tracking-ios.mdx
@@ -160,6 +160,12 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 The following are the valid values for the `type` key of a Custom Issue Field.
 
 - "singleline"

--- a/docs/sdkx-unity/tracking-ios.mdx
+++ b/docs/sdkx-unity/tracking-ios.mdx
@@ -123,7 +123,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 2. Define your custom issue field `Dictionary`
 3. Add the `"type"` and `"value"` for that custom issue field
 4. Add the custom issue field map to top level map (with key as your configured key and value as custom issue field map)
-5. Pass the map to `configMap` with key `"customIssueFields"` of the `ShowConversation(configMap)`
+5. Pass the map to `configMap` with key `"cifs"` of the `ShowConversation(configMap)`
 
 ```csharp
 
@@ -153,7 +153,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
     Map<String, Object> config = new HashMap<>();
     // other configs...
     //..
-    config.put("customIssueFields", cifMap);
+    config.put("cifs", cifMap);
 
     Helpshift.showConversation(MainActivity.this, config);
 
@@ -194,8 +194,8 @@ In the **Breadcrumbs** and **Debug logs** APIs, passing of formatted strings is 
 
 <p className="m-0">For example:</p>
 
-* "{\"key\":\"value\"}" - ** JSON String, This is NOT supported **
-* "key - value" - ** Simple string, This is supported **
+- "{\"key\":\"value\"}" - ** JSON String, This is NOT supported **
+- "key - value" - ** Simple string, This is supported **
 
 </Admonition>
 

--- a/docs/sdkx_android/migration-guide.mdx
+++ b/docs/sdkx_android/migration-guide.mdx
@@ -174,7 +174,7 @@ Update the configuration passed in conversation and FAQ APIs as following.
 | Legacy SDK ApiConfig                                    | SDK X: Key in Map                                                                                                       |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | ApiConfig.Builder.setEnableFullPrivacy                  | "fullPrivacy"                                                                                                           |
-| ApiConfig.Builder.setCustomIssueFields                  | "customIssueFields"                                                                                                     |
+| ApiConfig.Builder.setCustomIssueFields                  | "cifs"                                                                                                                  |
 | ApiConfig.Builder.setShowConversationResolutionQuestion | Moved to Helpshift Admin Dashboard. <br /> Under App settings → Resolution Experience → Resolution Question toggle      |
 | ApiConfig.Builder.setEnableTypingIndicator              | Moved to Helpshift Admin Dashboard. <br /> Under App settings → Support Experience → Show Agent Typing Indicator toggle |
 | Other configs from `ApiConfig` have been removed        | Currently, other configs are not supported                                                                              |
@@ -436,20 +436,20 @@ Map<String, Object> config = new HashMap<>();
 If you have following CIFs set in legacy SDK :
 
 ```java
-Map<String, String[]> customIssueFields = new HashMap<>();
-customIssueFields.put("join_date", new String[]{"dt", "1505927361535"});
-customIssueFields.put("level", new String[]{"n", "42"});
-customIssueFields.put("name", new String[]{"sl", "John Doe"});
-customIssueFields.put("address", new String[]{"ml", "3346, Sunny Glen Lane, Warrensville Heights, Ohio - 44128"});
-customIssueFields.put("is_pro", new String[]{"b", "true"});
-customIssueFields.put("currency", new String[]{"dd", "Dollar"});
+Map<String, String[]> cifs = new HashMap<>();
+cifs.put("join_date", new String[]{"dt", "1505927361535"});
+cifs.put("level", new String[]{"n", "42"});
+cifs.put("name", new String[]{"sl", "John Doe"});
+cifs.put("address", new String[]{"ml", "3346, Sunny Glen Lane, Warrensville Heights, Ohio - 44128"});
+cifs.put("is_pro", new String[]{"b", "true"});
+cifs.put("currency", new String[]{"dd", "Dollar"});
 
 ...
 ...
 
 private void showHelp() {
          ApiConfig apiConfig = new ApiConfig.Builder()
-                                            .setCustomIssueFields(customIssueFields)
+                                            .setCustomIssueFields(cifs)
                                             .build();
         Support.showFAQs(MainActivity.this, apiConfig);
 ```
@@ -493,7 +493,7 @@ Map<String, String> joiningDate = new HashMap<>();
     Map<String, Object> config = new HashMap<>();
     // other configs...
     //..
-    config.put("customIssueFields", cifMap);
+    config.put("cifs", cifMap);
 
     Helpshift.showFAQs(MainActivity.this, config);
 ```

--- a/docs/sdkx_android/migration-guide.mdx
+++ b/docs/sdkx_android/migration-guide.mdx
@@ -498,6 +498,12 @@ Map<String, String> joiningDate = new HashMap<>();
     Helpshift.showFAQs(MainActivity.this, config);
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 Please refer to this document for further details - [CIF - Helpshift SDK X Android](/sdkx_android/tracking#set-custom-issue-fields)
 
 ## Helpshift Delegates {#delegates}

--- a/docs/sdkx_android/outbound-support.mdx
+++ b/docs/sdkx_android/outbound-support.mdx
@@ -178,7 +178,7 @@ public class MainActivity extends AppCompatActivity implements HelpshiftProactiv
     isPro.put("value", "true");
     cifMap.put("is_pro", isPro);
 
-    localConfig.put("customIssueFields", cifMap);
+    localConfig.put("cifs", cifMap);
     ..etc
     return localConfig;
   }

--- a/docs/sdkx_android/outbound-support.mdx
+++ b/docs/sdkx_android/outbound-support.mdx
@@ -184,3 +184,9 @@ public class MainActivity extends AppCompatActivity implements HelpshiftProactiv
   }
 }
 ```
+
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>

--- a/docs/sdkx_android/support-tools.mdx
+++ b/docs/sdkx_android/support-tools.mdx
@@ -67,6 +67,12 @@ Example:
     Helpshift.showConversation(MainActivity.this, config);
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 `Helpshift.showConversation(MyActivity.this, configMap);` where `MyActivity.this` is the Activity you're calling Helpshift from and `configMap` is the configuration map that you want to pass to configure the SDK.
 
 Supports these [API Options](/sdkx_android/sdk-configuration/).

--- a/docs/sdkx_android/support-tools.mdx
+++ b/docs/sdkx_android/support-tools.mdx
@@ -59,7 +59,7 @@ Example:
     isPro.put("value", "true");
     cifMap.put("is_pro", isPro);
 
-    config.put("customIssueFields", cifMap);
+    config.put("cifs", cifMap);
 
     //..etc
 

--- a/docs/sdkx_android/tracking.mdx
+++ b/docs/sdkx_android/tracking.mdx
@@ -92,8 +92,9 @@ Helpshift.showConversation(MainActivity.this, config);
 You can attach Custom Issue Fields to every new conversation started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `cifs` key in API config map.
 
 <Admonition type="info" title="Note">
-  We are deprecating the use of the "customIssueFields" key and introducing a
-  new key called "cifs" to pass custom issue fields.
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
 </Admonition>
 
 These custom issue fields will be sent whenever an end user starts a new conversation or creates an issue via Smart FAQs.

--- a/docs/sdkx_android/tracking.mdx
+++ b/docs/sdkx_android/tracking.mdx
@@ -89,7 +89,14 @@ Helpshift.showConversation(MainActivity.this, config);
 
 ## Attaching Custom Issue Fields to conversations {#set-custom-issue-fields}
 
-You can attach Custom Issue Fields to every new conversation started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `customIssueFields` key in API config map. These Custom Issue Fields would be sent whenever a new conversation is started by the end user.
+You can attach Custom Issue Fields to every new conversation started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `cifs` key in API config map.
+
+<Admonition type="info" title="Note">
+  We are deprecating the use of the "customIssueFields" key and introducing a
+  new key called "cifs" to pass custom issue fields.
+</Admonition>
+
+These custom issue fields will be sent whenever an end user starts a new conversation or creates an issue via Smart FAQs.
 
 As soon as an end user opens the conversation screen, they see a greeting message, and the conversation is considered active. All the modified Custom Issue Fields (updated during an active conversation) will only be sent with the next conversation that end user starts.
 
@@ -99,7 +106,7 @@ If you want to set Custom Issue Fields at the time of Issue creation, follow the
 2. For each custom issue field, define your custom issue field `Map`
 3. Add the `"type"` and `"value"` for that custom issue field in custom issue field map.
 4. Add the custom issue field map to top level map (with key as your configured key and value as custom issue field map)
-5. Pass the map to `configMap` with key `"customIssueFields"` of the `Helpshift.showConversation(this, configMap)`
+5. Pass the map to `configMap` with key `"cifs"` of the `Helpshift.showConversation(this, configMap)`
 
 ```java
 Map<String, Object> joiningDate = new HashMap<>();
@@ -127,21 +134,21 @@ cifMap.put("is_pro", isPro);
 Map<String, Object> config = new HashMap<>();
 // other configs...
 //..
-config.put("customIssueFields", cifMap);
+config.put("cifs", cifMap);
 
 Helpshift.showConversation(MainActivity.this, config);
 ```
 
 Possible datatypes to be passed into the config are:
 
-| Type         | value         | Comments                                                                                                                                                      |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "singleline" | string        | Single line string with character limit of 255                                                                                                                |
-| "multiline"  | string        | Multi line string with character limit of 100,000                                                                                                             |
-| "number"     | string        | String representation of number. For eg. "12345"                                                                                                              |
-| "dropdown"   | string        | Drop-down options should exist for the given Custom Issue Field on dashboard. Value should be one of the values specified on the dashbaord for that dropdown. |
-| "date"       | long          | Epoch time in milliseconds. For eg. `1505927361535`                                                                                                           |
-| "checkbox"   | string        | String representation of boolean. For eg. "true" or "false". This corresponds to the checkbox type custom issue field on dashboard.                           |
+| Type         | value  | Comments                                                                                                                                                      |
+| ------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "singleline" | string | Single line string with character limit of 255                                                                                                                |
+| "multiline"  | string | Multi line string with character limit of 100,000                                                                                                             |
+| "number"     | string | String representation of number. For eg. "12345"                                                                                                              |
+| "dropdown"   | string | Drop-down options should exist for the given Custom Issue Field on dashboard. Value should be one of the values specified on the dashbaord for that dropdown. |
+| "date"       | long   | Epoch time in milliseconds. For eg. `1505927361535`                                                                                                           |
+| "checkbox"   | string | String representation of boolean. For eg. "true" or "false". This corresponds to the checkbox type custom issue field on dashboard.                           |
 
 <Admonition type="info" title="Note">
 

--- a/docs/sdkx_ios/migration-guide.mdx
+++ b/docs/sdkx_ios/migration-guide.mdx
@@ -388,6 +388,12 @@ NSDictionary *config = @{ @"cifs" : cifs };
 [Helpshift showConversationWith:self config:config];
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 ##### Breadcrumbs & Debug logs
 
 | Action            | Legacy SDK API                                         | SDK X API                                       |

--- a/docs/sdkx_ios/migration-guide.mdx
+++ b/docs/sdkx_ios/migration-guide.mdx
@@ -23,7 +23,7 @@ import {
 
 <Intro>
 
-SDK X is a Hybrid SDK that helps you roll out innovation faster by enabling most of the updates over the air that flow to end users without any downtime or app updates. 
+SDK X is a Hybrid SDK that helps you roll out innovation faster by enabling most of the updates over the air that flow to end users without any downtime or app updates.
 
 This migration guide will walk you through the steps you need to take in order to migrate from Helpshift legacy SDK to SDK X.
 
@@ -161,7 +161,7 @@ The conversation and FAQ APIs in SDK X take a dictionary parameter rather than `
 | ---------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------- |
 | presentFullScreenOniPad            | presentFullScreenOniPad  | -                                                                                                     |
 | enableFullPrivacy                  | enableFullPrivacy        | -                                                                                                     |
-| customIssueFields                  | customIssueFields        | -                                                                                                     |
+| customIssueFields                  | cifs                     | -                                                                                                     |
 | showConversationResolutionQuestion | -                        | Moved to admin dashboard under App settings → Resolution Experience → Resolution Question toggle      |
 | enableTypingIndicator              | -                        | Moved to admin dashboard under App settings → Support Experience → Show Agent Typing Indicator toggle |
 |                                    |                          |                                                                                                       |
@@ -177,7 +177,7 @@ Replace the following APIs for user login/logout -
 Replace legacy SDK login code -
 
 ```objc
-HelpshiftUserBuilder *userBuilder = [[HelpshiftUserBuilder alloc] initWithIdentifier:@"unique-user-id-746501" 
+HelpshiftUserBuilder *userBuilder = [[HelpshiftUserBuilder alloc] initWithIdentifier:@"unique-user-id-746501"
           andEmail:@"john.doe@app.co"];
 userBuilder.name = @"John Doe";
 userBuilder.authToken = @"generated-user-authentication-token";
@@ -384,7 +384,7 @@ NSDictionary *cifs = @{ @"name": @{ @"type":@"singleline", @"value":@"John Doe" 
                     @"currency": @{ @"type":@"dropdown", @"value":@"Dollar" },
                    @"join_date": @{ @"type":@"date", @"value":@"1505927361535" } };
 
-NSDictionary *config = @{ @"customIssueFields" : cifs };
+NSDictionary *config = @{ @"cifs" : cifs };
 [Helpshift showConversationWith:self config:config];
 ```
 

--- a/docs/sdkx_ios/outbound-support.mdx
+++ b/docs/sdkx_ios/outbound-support.mdx
@@ -177,7 +177,7 @@ For example, following code shows how to implement `HelpshiftProactiveAPIConfigC
 // Delegate callback
 - (nonnull NSDictionary *) getAPIConfig {
     NSDictionary *config = @{ @"tags":tagsArray,
-                              @"customIssueFields": cifDictionary };
+                              @"cifs": cifDictionary };
     ..
     return localConfig;
 }
@@ -194,7 +194,7 @@ Helpshift.sharedInstance.setProactiveAPIConfigCollectorDelegate(self)
 func getAPIConfig() -> Dictionary<String, Any> {
     var config: [String: Any] = [
         "tags": tagsArray,
-        "customIssueFields": cifDictionary
+        "cifs": cifDictionary
     ]
     ...
     return config

--- a/docs/sdkx_ios/outbound-support.mdx
+++ b/docs/sdkx_ios/outbound-support.mdx
@@ -183,6 +183,12 @@ For example, following code shows how to implement `HelpshiftProactiveAPIConfigC
 }
 ```
 
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
+
 </TabItem>
 <TabItem value="Swift" label="Swift">
 
@@ -200,6 +206,12 @@ func getAPIConfig() -> Dictionary<String, Any> {
     return config
 }
 ```
+
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
 
 </TabItem>
 

--- a/docs/sdkx_ios/tracking.mdx
+++ b/docs/sdkx_ios/tracking.mdx
@@ -124,7 +124,14 @@ Helpshift.showConversation(with: self, config: config)
 
 ## Attaching Custom Issue Fields to conversations {#custom-issue-fields}
 
-You can attach Custom Issue Fields to every new conversation started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `customIssueFields` key in API config dictionary. These Custom Issue Fields would be sent whenever a new conversation is started by the end user.
+You can attach Custom Issue Fields to every new conversation started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `cifs` key in API config dictionary.
+
+<Admonition type="info" title="Note">
+  We are deprecating the use of the "customIssueFields" key and introducing a
+  new key called "cifs" to pass custom issue fields.
+</Admonition>
+
+These custom issue fields will be sent whenever an end user starts a new conversation or creates an issue via Smart FAQs.
 
 As soon as an end user opens the conversation screen, they see a greeting message, and the conversation is considered active. All the modified Custom Issue Fields (updated during an active conversation) will only be sent with the next conversation that end user starts.
 
@@ -141,7 +148,7 @@ NSDictionary *cifs = @{ @"joining_date": @{ @"type":@"date", @"value":@150592736
                     @"employee_address": @{ @"type":@"multiline", @"value":@"303,Joy plaza,Park street,Viman nagar.Pune-432123" },
                      @"salary_currency": @{ @"type":@"dropdown", @"value":@"Dollars" } };
 
-NSDictionary *config = @{ @"customIssueFields" : cifs };
+NSDictionary *config = @{ @"cifs" : cifs };
 [Helpshift showConversationWith:self config:config];
 ```
 
@@ -155,7 +162,7 @@ let cifs = [ "joining_date": ["type":"date", "value":1505927361535],
              "employee_name": ["type":"singleline", "value":"ABC"],
              "employee_address": ["type":"multiline", "value":"303,Joy plaza,Park street,Viman nagar.Pune-432123"],
              "salary_currency": ["type":"dropdown", "value":"Dollars"]];
-let config = ["customIssueFields":cifs]
+let config = ["cifs":cifs]
 Helpshift.showConversation(with: self, config: config)
 ```
 
@@ -165,14 +172,14 @@ Helpshift.showConversation(with: self, config: config)
 
 Possible datatypes to be passed into the config are:
 
-| Type         | value         | Comments                                                                                                                                                      |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "singleline" | string        | Single line string with character limit of 255                                                                                                                |
-| "multiline"  | string        | Multi line string with character limit of 100,000                                                                                                             |
-| "number"     | string        | String representation of number. For eg. "12345"                                                                                                              |
-| "dropdown"   | string        | Drop-down options should exist for the given Custom Issue Field on dashboard. Value should be one of the values specified on the dashbaord for that dropdown. |
-| "date"       | NSNumber      | Epoch time in milliseconds. For eg. `1505927361535`                                                                                                           |
-| "checkbox"   | string        | String representation of boolean. For eg. "true" or "false". This corresponds to the checkbox type custom issue field on dashboard.                           |
+| Type         | value    | Comments                                                                                                                                                      |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "singleline" | string   | Single line string with character limit of 255                                                                                                                |
+| "multiline"  | string   | Multi line string with character limit of 100,000                                                                                                             |
+| "number"     | string   | String representation of number. For eg. "12345"                                                                                                              |
+| "dropdown"   | string   | Drop-down options should exist for the given Custom Issue Field on dashboard. Value should be one of the values specified on the dashbaord for that dropdown. |
+| "date"       | NSNumber | Epoch time in milliseconds. For eg. `1505927361535`                                                                                                           |
+| "checkbox"   | string   | String representation of boolean. For eg. "true" or "false". This corresponds to the checkbox type custom issue field on dashboard.                           |
 
 <Admonition type="info" title="Note">
 

--- a/docs/sdkx_ios/tracking.mdx
+++ b/docs/sdkx_ios/tracking.mdx
@@ -127,8 +127,9 @@ Helpshift.showConversation(with: self, config: config)
 You can attach Custom Issue Fields to every new conversation started by the user. A Custom Issue Field should have a key, a datatype, and a value. The Helpshift SDK allows the addition of Custom Issue Fields by using the `cifs` key in API config dictionary.
 
 <Admonition type="info" title="Note">
-  We are deprecating the use of the "customIssueFields" key and introducing a
-  new key called "cifs" to pass custom issue fields.
+  We would like to inform you that the usage of the customIssueFields key will
+  be deprecated. We strongly recommend transitioning to using the cifs key as
+  the preferred method for passing custom issue fields.
 </Admonition>
 
 These custom issue fields will be sent whenever an end user starts a new conversation or creates an issue via Smart FAQs.
@@ -169,6 +170,12 @@ Helpshift.showConversation(with: self, config: config)
 </TabItem>
 
 </Tabs>
+
+<Admonition type="info" title="Note">
+  We would like to inform you that the usage of the <b>"customIssueFields"</b>{" "}
+  key will be deprecated. We strongly recommend transitioning to using the{" "}
+  <b>"cifs"</b> key as the preferred method for passing custom issue fields.
+</Admonition>
 
 Possible datatypes to be passed into the config are:
 


### PR DESCRIPTION
## Description

- Inform that we are deprecating the use of the `"customIssueFields"` key and introducing a new key called `"cifs"` to pass custom issue fields.
- Replace the `"customIssueFields"` key with the `"cifs"` key in sdkx_android docs
- Replace the `"customIssueFields"` key with the `"cifs"` key in sdkx_ios docs
- Replace the `"customIssueFields"` key with the `"cifs"` key in freesdk docs
- Replace the `"customIssueFields"` key with the `"cifs"` key in sdkx-unity docs
- Replace the `"customIssueFields"` key with the `"cifs"` key in sdkx-react-native docs
- Update the deprecation note for the `customIssueFields` key on the sdkx_android docs
- Update the deprecation note for the `customIssueFields` key on the sdkx_ios docs
- Update the deprecation note for the `customIssueFields` key on the freesdk docs
- Update the deprecation note for the `customIssueFields` key on the sdkx-unity docs
- Update the deprecation note for the `customIssueFields` key on the sdkx-react-native docs
