### PR TITLE
Update getting-started-android.mdx

### DIFF
--- a/docs/unity/getting-started-android.mdx
+++ b/docs/unity/getting-started-android.mdx
@@ -120,13 +120,13 @@ Update **dependencies** section of the `mainTemplate.gradle` or `build.gradle` f
 
 ```
     dependencies {
-        compile fileTree(dir: 'libs', include: ['*.jar'])
-        compile(name: 'Helpshift', ext:'aar')
-        compile(name: 'helpshift-plugin-resources', ext:'aar')
+        implementation fileTree(dir: 'libs', include: ['*.jar'])
+        implementation(name: 'Helpshift', ext:'aar')
+        implementation(name: 'helpshift-plugin-resources', ext:'aar')
         implementation(':helpshift-plugin-wrapper')
-        compile 'com.android.support:design:26.0.2'
-        compile 'com.android.support:recyclerview-v7:26.0.2'
-        compile 'com.android.support:cardview-v7:26.0.2'
+        implementation 'com.android.support:design:26.0.2'
+        implementation 'com.android.support:recyclerview-v7:26.0.2'
+        implementation 'com.android.support:cardview-v7:26.0.2'
     }
 ```
 

--- a/docs/unity/getting-started-android.mdx
+++ b/docs/unity/getting-started-android.mdx
@@ -123,7 +123,7 @@ Update **dependencies** section of the `mainTemplate.gradle` or `build.gradle` f
         implementation fileTree(dir: 'libs', include: ['*.jar'])
         implementation(name: 'Helpshift', ext:'aar')
         implementation(name: 'helpshift-plugin-resources', ext:'aar')
-        implementation(':helpshift-plugin-wrapper')
+        implementation project(':helpshift-plugin-wrapper')
         implementation 'com.android.support:design:26.0.2'
         implementation 'com.android.support:recyclerview-v7:26.0.2'
         implementation 'com.android.support:cardview-v7:26.0.2'

--- a/docs/unity/getting-started-android.mdx
+++ b/docs/unity/getting-started-android.mdx
@@ -123,7 +123,7 @@ Update **dependencies** section of the `mainTemplate.gradle` or `build.gradle` f
         compile fileTree(dir: 'libs', include: ['*.jar'])
         compile(name: 'Helpshift', ext:'aar')
         compile(name: 'helpshift-plugin-resources', ext:'aar')
-        compile project(':helpshift-plugin-wrapper')
+        implementation(':helpshift-plugin-wrapper')
         compile 'com.android.support:design:26.0.2'
         compile 'com.android.support:recyclerview-v7:26.0.2'
         compile 'com.android.support:cardview-v7:26.0.2'


### PR DESCRIPTION
For Unity 2020 and above "compile project(':helpshift-plugin-wrapper')" =>"implementation(':helpshift-plugin-wrapper')"