### PR TITLE
Specify identity system limits for Web Chat

### DIFF
--- a/docs/sdkx_android/delegates.mdx
+++ b/docs/sdkx_android/delegates.mdx
@@ -512,8 +512,8 @@ The constants for value of data is present in `InvalidDataErrorReason` file.
 Where applicable, the max permissible limits are defined as follows -
 
 - Key length - Max 255 chars
-- Value length for identity - Max 300 chars
-- Value length for UID identity - Max 750 chars
+- Value length for any identity (except `uid`) - Max 300 chars
+- Value length for `uid` identity - Max 750 chars
 - Value length for CUF - Max 255 chars
 - Value length for multiline CUF - Max 100000 chars
 - Value length for user tags - Max 100 chars

--- a/docs/sdkx_android/identity-user-hub.mdx
+++ b/docs/sdkx_android/identity-user-hub.mdx
@@ -14,7 +14,7 @@ import {
 
 <Admonition type="info" title="Note">
 
-All the public APIs in the SDK should be called after initializing the SDK via [Helpshift installWithPlatformId API](/sdkx_android/getting-started#start-using)
+All the public APIs in the SDK should be called after initializing the SDK via [Helpshift.install() API](/sdkx_android/getting-started#start-using)
 
 </Admonition>
 
@@ -192,13 +192,13 @@ Global attributes must be one of the following types -
 - `full_name` - String
 - `last_country` - String
 - `last_city` - String
-- `age` - Int or String
-- `lifetime_value` - String
+- `age` - String (String value of Integer)
+- `lifetime_value` - String (String value of Integer)
 - `user_persona` - String
 - `user_vip_segment` - String
 - `user_support_status` - String
 - `last_active_date` - String // UNIX epoch time in seconds
-- `accepted_t_and_c` - String
+- `accepted_t_and_c` - String ("true" or "false")
 - `preferred_language` - String
 - `new_tags` - List< String >
 - `tags_to_remove` - List< String >
@@ -236,7 +236,7 @@ App specific attributes must be one of the following types -
 - `user_paying_segment` - String
 - `user_support_status` - String
 - `user_persona` - String
-- `accepted_t_and_c` - String
+- `accepted_t_and_c` - String ("true" or "false")
 - `user_level` - String
 - `app_status` - String
 - `lifetime_value` - String

--- a/docs/sdkx_ios/delegates.mdx
+++ b/docs/sdkx_ios/delegates.mdx
@@ -736,8 +736,8 @@ When using Identity system related APIs, the related events are communicated to 
 Where applicable, the max permissible limits are defined as follows -
 
 - Key length - Max 255 chars
-- Value length for identity - Max 300 chars
-- Value length for UID identity - Max 750 chars
+- Value length for any identity (except `uid`) - Max 300 chars
+- Value length for `uid` identity - Max 750 chars
 - Value length for CUF - Max 255 chars
 - Value length for multiline CUF - Max 100000 chars
 - Value length for user tags - Max 100 chars

--- a/docs/web-chat/identity-users.mdx
+++ b/docs/web-chat/identity-users.mdx
@@ -395,7 +395,20 @@ If your login is still failing, you can investigate these other potential reason
 3. Ensure that your JWT endpoint has an `iat` (issued_at_time) value that is NOT older than 24h
 4. In case you are caching the JWT, ensure that you do not cache it for longer than 24h.
 
-## API failure reasons
+## System limits
+
+When using the User Identity APIs, the following system-level limits are applicable. Where applicable, these
+limits will also be reported to you as documented in the [API failure reasons](#api-failure-reasons).
+
+* Key lengths across all APIs - Max 255 chars
+* Value length for any identity (except `uid`) - Max 300 chars
+* Value length for `uid` identity - Max 750 chars
+* Value length for CUF - Max 255 chars
+* Value length for multiline CUF - Max 100000 chars
+* Value length for user tags - Max 100 chars
+* Collection size - Max 30 entries
+
+## API failure reasons {#api-failure-reasons}
 
 You can subscribe to the [onWebChatRuntimeError](/web-chat/api/#on-webchat-runtime-error) event
 to handle these errors programmatically. The following errors are emitted for the User Identity APIs:


### PR DESCRIPTION
+ We had mentioned these partially in the API failure reason docs, but we need to centralize the limits for an easier DevX
+ Updated the iOS and Android copy to make it easier to understand the `uid` and non-uid identity limit difference