### PR TITLE
Add notification page in PC widget Unity section

### DIFF
--- a/docs/pc-widget-unity/notifications.mdx
+++ b/docs/pc-widget-unity/notifications.mdx
@@ -1,0 +1,15 @@
+---
+sidebar_position: 80
+title: Notifications
+description: "PC Widget supports in-app notifications by default, without any additional configuration."
+---
+
+import {
+  Intro,
+} from "@site/src/components/forDocs";
+
+<Intro>
+
+PC Widget supports in-app notifications by default, without any additional configuration.
+
+</Intro>


### PR DESCRIPTION
+ Add info about notifications in the PC widget Unity section of the documentation.

Tests:

+ The notifications page is visible in the PC widget Unity section.
+ The right content is displayed on the notifications page.